### PR TITLE
Make sure /var/lib/overlay exists before relabeling

### DIFF
--- a/selinux/98selinux-microos/selinux-microos-relabel.sh
+++ b/selinux/98selinux-microos/selinux-microos-relabel.sh
@@ -21,6 +21,14 @@ rd_microos_relabel()
         ret=0
         info "SELinux: relabeling root filesystem"
 
+	# If this doesn't exist because e.g. it's not mounted yet due to a bug
+	# (boo#1197309), the exclusion is ignored. If it gets mounted during
+	# the relabel, it gets wrong labels assigned.
+	if ! [ -d "$NEWROOT/var/lib/overlay" ]; then
+	    warn "ERROR: /var/lib/overlay doesn't exist - /var not mounted (yet)?"
+            return 1
+	fi
+
 	for sysdir in /proc /sys /dev; do
 	    if ! mount --rbind "${sysdir}" "${NEWROOT}${sysdir}" ; then
 		warn "ERROR: mounting ${sysdir} failed!"


### PR DESCRIPTION
See the added comment for the rationale.

This doesn't do anything on its own, but tries to make sure that it doesn't destroy `/var/lib/overlay` (also breaking other snapshots) by accident.